### PR TITLE
Copy current line without selecting it

### DIFF
--- a/src/EditorContent.cpp
+++ b/src/EditorContent.cpp
@@ -271,6 +271,10 @@ sf::String EditorContent::getLine(int line) {
     return this->document.getLine(line);
 }
 
+sf::String EditorContent::getCursorLine() {
+    return this->getLine(cursor.getLineN());
+}
+
 // TODO: column != charN
 void EditorContent::resetCursor(int line, int column) {
     this->cursor.setPosition(line, column);

--- a/src/EditorContent.h
+++ b/src/EditorContent.h
@@ -41,6 +41,7 @@ class EditorContent {
     int linesCount();
     int colsInLine(int line);
     sf::String getLine(int line);
+    sf::String getCursorLine();
 
     void resetCursor(int line, int column);
     std::pair<int, int> cursorPosition();

--- a/src/InputController.cpp
+++ b/src/InputController.cpp
@@ -139,6 +139,9 @@ void InputController::handleKeyPressedEvents(EditorView &textView, sf::Event &ev
                 editorContent.addTextInCursorPos(emoji);
             } else if (event.key.code == sf::Keyboard::C) {  //Copy command, Ctrl + C
                 this->stringCopied = editorContent.copySelections();
+                if (this->stringCopied.isEmpty()) {
+                    this->stringCopied = editorContent.getCursorLine();
+                }
             } else if (event.key.code == sf::Keyboard::V) {  //Paste command, Ctrl + V
                 editorContent.addTextInCursorPos(stringCopied);
             } else if (event.key.code == sf::Keyboard::X) {  //Cut command, Ctrl + X


### PR DESCRIPTION
Added the ability to copy the current line (Ctrl+C) without selecting it first.